### PR TITLE
Updated to extra_state_attributes

### DIFF
--- a/custom_components/snoo/sensor.py
+++ b/custom_components/snoo/sensor.py
@@ -38,7 +38,7 @@ class SnooStateSensor(Entity):
         return self._state.value
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return device specific state attributes."""
         return self._attributes
 


### PR DESCRIPTION
Usage of device_state_attributes is deprecated in Home Assistant 2021.12